### PR TITLE
pokur: make minor tweak to work with %ziggurat

### DIFF
--- a/src/zig/custom-step-definitions/send-wallet-transaction.hoon
+++ b/src/zig/custom-step-definitions/send-wallet-transaction.hoon
@@ -15,7 +15,7 @@
   :~  :+  %scry
         :-  who
         :^  '(map @ux *)'  %gx  %wallet
-        /pending-store/(scot %ux address)/noun
+        /pending-store/(scot %ux address)/noun/noun
       ''
   ::
       ::  TODO: avoid this stupid compiler-satisfying pattern
@@ -29,7 +29,7 @@
       :+  %scry
         :-  who
         :^  '(map @ux *)'  %gx  %wallet
-        /pending-store/(scot %ux address)/noun
+        /pending-store/(scot %ux address)/noun/noun
       ''
   ::
       :+  %poke

--- a/src/zig/test-steps/wes-join-table.hoon
+++ b/src/zig/test-steps/wes-join-table.hoon
@@ -19,7 +19,7 @@
     :+  %scry
       :-  who
       :^  'update:pokur'  %gx  %pokur
-      /lobby/noun
+      /lobby/noun/noun
     ''
   ::
     :^  %custom-write  %send-wallet-transaction
@@ -54,7 +54,7 @@
     :+  %scry
       :-  who
       :^  '[@t boat:gall bitt:gall]'  %gx  %subscriber
-      /agent-state/pokur/noun
+      /agent-state/pokur/''/noun/noun
     ''
   ==
 --


### PR DESCRIPTION
Scrying changed recently in %pyro-%ziggurat so that the double mark is exposed via %ziggurat -- so update the custom-step-definition to use it properly here.